### PR TITLE
Disable overlapping MLflow autologging and dev-only request logging

### DIFF
--- a/agent_app/agent_server/agent.py
+++ b/agent_app/agent_server/agent.py
@@ -45,7 +45,14 @@ logger = logging.getLogger(__name__)
 def _enable_mlflow_langchain_autolog() -> None:
     """Best-effort autolog setup that does not break unit-test imports."""
     try:
-        mlflow.langchain.autolog(run_tracer_inline=True)
+        # Uncomment this when you also want to include autologging.
+        # Many autologged spans will overlap with manual tracing, so you may
+        # want to disable autologging in that case. `run_tracer_inline=True`
+        # forces MLflow to process traces synchronously, which helps avoid
+        # losing them in async execution.
+        
+        # mlflow.langchain.autolog(run_tracer_inline=True)
+        mlflow.langchain.autolog(disable=True)
     except Exception as exc:
         logger.warning("Skipping mlflow.langchain.autolog setup: %s", exc)
 

--- a/agent_app/e2e-chatbot-app-next/packages/ai-sdk-providers/src/providers-server.ts
+++ b/agent_app/e2e-chatbot-app-next/packages/ai-sdk-providers/src/providers-server.ts
@@ -75,6 +75,7 @@ export async function getWorkspaceHostname(): Promise<string> {
 
 // Environment variable to enable SSE logging
 const LOG_SSE_EVENTS = process.env.LOG_SSE_EVENTS === 'true';
+const IS_DEVELOPMENT = process.env.NODE_ENV !== 'production';
 
 const API_PROXY = process.env.API_PROXY;
 
@@ -228,8 +229,8 @@ export const databricksFetch: typeof fetch = async (input, init) => {
     }
   }
 
-  // Log the request being sent to Databricks
-  if (requestInit?.body) {
+  // Only log full outbound request bodies during local development.
+  if (IS_DEVELOPMENT && requestInit?.body) {
     try {
       const requestBody =
         typeof requestInit.body === 'string'


### PR DESCRIPTION
## Summary
- disable MLflow LangChain autologging to avoid overlapping spans with the manual tracing already added on this branch
- keep the Databricks outbound request-body logging available for local development, but stop emitting those bodies in production

## Test plan
- Not run (not requested)