### PR TITLE
Restore MLflow LangChain autologging

### DIFF
--- a/agent_app/agent_server/agent.py
+++ b/agent_app/agent_server/agent.py
@@ -51,8 +51,8 @@ def _enable_mlflow_langchain_autolog() -> None:
         # forces MLflow to process traces synchronously, which helps avoid
         # losing them in async execution.
         
-        # mlflow.langchain.autolog(run_tracer_inline=True)
-        mlflow.langchain.autolog(disable=True)
+        mlflow.langchain.autolog(run_tracer_inline=True)
+        # mlflow.langchain.autolog(disable=True)
     except Exception as exc:
         logger.warning("Skipping mlflow.langchain.autolog setup: %s", exc)
 


### PR DESCRIPTION
## Summary
- restore `mlflow.langchain.autolog(run_tracer_inline=True)` in the agent server
- revert the temporary change that disabled LangChain autologging

## Test plan
- Not run (not requested)