### PR TITLE
Reinforce visualization workspace fallback handling

### DIFF
--- a/agent_app/agent_server/agent.py
+++ b/agent_app/agent_server/agent.py
@@ -10,7 +10,7 @@ import os
 import sys
 import threading
 import time
-from typing import AsyncGenerator, Optional
+from typing import Any, AsyncGenerator, Optional
 from uuid import uuid4
 
 import litellm
@@ -512,6 +512,40 @@ def _make_json_serializable(obj):
         return f"<{type(obj).__name__}>"
 
 
+def _extract_merged_state(app: Any, run_config: dict, last_state: dict) -> dict:
+    merged_state: dict[str, Any] = {}
+
+    if isinstance(last_state, dict):
+        merged_state.update(last_state)
+        for value in last_state.values():
+            if isinstance(value, dict):
+                for key, nested_value in value.items():
+                    merged_state.setdefault(key, nested_value)
+
+    try:
+        latest_state = app.get_state(run_config)
+    except Exception:
+        logger.debug("Unable to fetch merged workflow state for trace outputs", exc_info=True)
+        return merged_state
+
+    state_values = getattr(latest_state, "values", None)
+    if isinstance(state_values, dict):
+        merged_state.update(state_values)
+
+    return merged_state
+
+
+def _build_summary_trace_metadata(summary: Optional[str]) -> dict[str, Any]:
+    if not summary:
+        return {}
+    workspace_count = summary.count("```viz-workspace")
+    return {
+        "final_summary_length": len(summary),
+        "has_viz_workspace": workspace_count > 0,
+        "viz_workspace_count": workspace_count,
+    }
+
+
 _CUSTOM_FORMATTERS = {
     "agent_thinking": lambda d: f"{d['agent'].upper()}: {d['content']}",
     "agent_start": lambda d: f"Starting {d['agent']} agent for: {d.get('query', '')}",
@@ -876,12 +910,13 @@ Guidelines:
                         last_state = {}
                         continue
 
+                trace_state = _extract_merged_state(app, run_config, last_state)
                 workflow_output: dict = {"status": "completed"}
-                if summary := last_state.get("final_summary"):
-                    workflow_output["final_summary"] = summary
-                if sql := last_state.get("sql_query"):
+                if summary := trace_state.get("final_summary"):
+                    workflow_output.update(_build_summary_trace_metadata(summary))
+                if sql := trace_state.get("sql_query"):
                     workflow_output["sql_query"] = sql
-                if er := last_state.get("execution_result"):
+                if er := trace_state.get("execution_result"):
                     workflow_output["execution_result_status"] = er.get("status")
                     workflow_output["row_count"] = er.get("row_count")
                 span.set_outputs(workflow_output)
@@ -1110,13 +1145,21 @@ Guidelines:
         f"Workflow completed (thread: {thread_id}) "
         f"TTFT={first_token_time - workflow_start_time if first_token_time else 'N/A'}s, TTCL={ttcl:.3f}s"
     )
-    request_span.set_outputs(
-        {
-            "thread_id": thread_id,
-            "request_id": request_id,
-            "ttft_seconds": first_token_time - workflow_start_time if first_token_time else None,
-            "ttcl_seconds": ttcl,
-            "first_token_emitted": first_token_time is not None,
-        }
-    )
+    final_state = {}
+    try:
+        final_app = _get_compiled_workflow_app()
+        final_state = _extract_merged_state(final_app, run_config, {})
+    except Exception:
+        logger.debug("Unable to fetch final workflow state for request span outputs", exc_info=True)
+
+    request_output = {
+        "thread_id": thread_id,
+        "request_id": request_id,
+        "ttft_seconds": first_token_time - workflow_start_time if first_token_time else None,
+        "ttcl_seconds": ttcl,
+        "first_token_emitted": first_token_time is not None,
+    }
+    if final_summary := final_state.get("final_summary"):
+        request_output.update(_build_summary_trace_metadata(final_summary))
+    request_span.set_outputs(request_output)
     request_span.end()

--- a/agent_app/agent_server/multi_agent/agents/chart_generator.py
+++ b/agent_app/agent_server/multi_agent/agents/chart_generator.py
@@ -1179,6 +1179,21 @@ Rules:
                 notes.append(
                     f"Converted timeBucket aggregation for pre-aggregated metric '{metric}' from count to sum"
                 )
+            if metric and normalized["function"] in {"count", "count_distinct"}:
+                synthetic_name = "Count"
+                if normalized["function"] == "count_distinct":
+                    synthetic_name = f"Distinct {metric.replace('_', ' ').title()} Count"
+                elif metric != "count":
+                    synthetic_name = metric.replace("_", " ").title()
+                normalized["syntheticSeries"] = [
+                    {
+                        "field": metric,
+                        "name": synthetic_name,
+                        "format": "number",
+                        "chartType": None,
+                        "axis": "primary",
+                    }
+                ]
             return normalized
 
         if transform_type == "histogram":

--- a/agent_app/agent_server/multi_agent/agents/summarize.py
+++ b/agent_app/agent_server/multi_agent/agents/summarize.py
@@ -267,6 +267,64 @@ def _build_visualization_workspace_payload(
     }
 
 
+def _build_fallback_chart_payload(
+    label: str,
+    source_row_count: int,
+    reason: str,
+) -> Dict[str, Any]:
+    return {
+        "config": {
+            "chartType": "bar",
+            "title": label,
+            "description": None,
+            "xAxisField": "__workspace_fallback__",
+            "groupByField": None,
+            "yAxisField": None,
+            "zAxisField": None,
+            "series": [
+                {
+                    "field": "row_count",
+                    "name": "Rows",
+                    "format": "number",
+                    "chartType": None,
+                    "axis": "primary",
+                }
+            ],
+            "layout": None,
+            "sortBy": None,
+            "toolbox": True,
+            "supportedChartTypes": ["bar"],
+            "referenceLines": [],
+            "compareLabels": None,
+            "transform": None,
+            "style": {
+                "palette": "default",
+                "showLegend": False,
+                "showLabels": True,
+                "showGridLines": True,
+                "showTitle": True,
+                "showDescription": False,
+                "smoothLines": False,
+            },
+        },
+        "chartData": [{"__workspace_fallback__": "Rows", "row_count": source_row_count}],
+        "downloadData": [{"__workspace_fallback__": "Rows", "row_count": source_row_count}],
+        "totalRows": source_row_count,
+        "aggregated": True,
+        "aggregationNote": reason,
+        "meta": {
+            "source": "fallback",
+            "rationale": "Rendered workspace fallback because chart generation was unavailable.",
+            "confidence": 0.35,
+            "description": reason,
+            "normalizationNotes": [reason],
+            "fallbackApplied": True,
+            "candidateFields": {"dimensions": [], "measures": ["row_count"]},
+            "businessInsight": "Table preview remains available even when automatic chart generation fails.",
+        },
+    }
+
+
 def get_cached_summarize_agent():
     """
     Get or create cached ResultSummarizeAgent instance.
@@ -690,21 +748,48 @@ def summarize_node(state: AgentState) -> dict:
 
         future_entry = chart_futures.get(idx)
         if not future_entry:
+            preview_rows = data[:MAX_PREVIEW_ROWS]
+            source_row_count = result_item.get("row_count") or len(data)
+            payload = _build_fallback_chart_payload(
+                label=entry.get("label") or f"Query {idx + 1}",
+                source_row_count=source_row_count,
+                reason="Chart generation was unavailable; showing the table preview with a fallback summary chart.",
+            )
+            workspace_payload = _build_visualization_workspace_payload(
+                entry=entry,
+                chart_payload=payload,
+                preview_rows=preview_rows,
+                full_rows=data,
+                source_row_count=source_row_count,
+                total_entries=len(artifact_entries),
+            )
+            workspace_json = _json.dumps(workspace_payload, default=str)
+            workspace_block = f"\n\n```viz-workspace\n{workspace_json}\n```\n"
+            summary += workspace_block
+            writer({"type": "text_delta", "content": workspace_block})
+            print(f"✓ Visualization workspace fallback inserted for result {idx} ({len(workspace_json)} bytes)")
             continue
         _future_meta, future = future_entry
 
         try:
+            preview_rows = data[:MAX_PREVIEW_ROWS]
+            source_row_count = result_item.get("row_count") or len(data)
+            fallback_reason = ""
             payload = future.result(timeout=30)
             if not payload:
+                fallback_reason = (
+                    "Chart generation returned no payload; showing the table preview with a fallback summary chart."
+                )
                 print(
                     "⚠ Chart generation returned no payload for result "
                     f"{idx} ({entry.get('label') or f'Query {idx + 1}'}) "
-                    f"columns={columns}"
+                    f"columns={columns}; using workspace fallback"
                 )
-                continue
-
-            preview_rows = data[:MAX_PREVIEW_ROWS]
-            source_row_count = result_item.get("row_count") or len(data)
+                payload = _build_fallback_chart_payload(
+                    label=entry.get("label") or f"Query {idx + 1}",
+                    source_row_count=source_row_count,
+                    reason=fallback_reason,
+                )
             workspace_payload = _build_visualization_workspace_payload(
                 entry=entry,
                 chart_payload=payload,
@@ -722,8 +807,28 @@ def summarize_node(state: AgentState) -> dict:
             print(
                 "⚠ Chart generation failed for result "
                 f"{idx} ({entry.get('label') or f'Query {idx + 1}'}) "
-                f"columns={columns}: {e}"
+                f"columns={columns}: {e}; using workspace fallback"
             )
+            preview_rows = data[:MAX_PREVIEW_ROWS]
+            source_row_count = result_item.get("row_count") or len(data)
+            payload = _build_fallback_chart_payload(
+                label=entry.get("label") or f"Query {idx + 1}",
+                source_row_count=source_row_count,
+                reason=f"Chart generation failed with error: {e}",
+            )
+            workspace_payload = _build_visualization_workspace_payload(
+                entry=entry,
+                chart_payload=payload,
+                preview_rows=preview_rows,
+                full_rows=data,
+                source_row_count=source_row_count,
+                total_entries=len(artifact_entries),
+            )
+            workspace_json = _json.dumps(workspace_payload, default=str)
+            workspace_block = f"\n\n```viz-workspace\n{workspace_json}\n```\n"
+            summary += workspace_block
+            writer({"type": "text_delta", "content": workspace_block})
+            print(f"✓ Visualization workspace fallback inserted for result {idx} ({len(workspace_json)} bytes)")
     if chart_pool:
         chart_pool.shutdown(wait=False)
 

--- a/agent_app/e2e-chatbot-app-next/client/src/components/elements/visualization-workspace.tsx
+++ b/agent_app/e2e-chatbot-app-next/client/src/components/elements/visualization-workspace.tsx
@@ -76,6 +76,10 @@ function buildInitialChartHistory(charts: ChartSpec[], workspaceId: string): Cha
 
 export function VisualizationWorkspace({ workspace }: VisualizationWorkspaceProps) {
   const messageId = useMessageId();
+  const prefersTablePreview = useMemo(
+    () => workspace.charts.some((chart) => chart.meta?.source === 'fallback' || chart.meta?.fallbackApplied),
+    [workspace.charts],
+  );
   const storageKey = messageId
     ? `viz-ws-${messageId}-${workspace.workspaceId}`
     : null;
@@ -84,8 +88,8 @@ export function VisualizationWorkspace({ workspace }: VisualizationWorkspaceProp
     [storageKey, workspace.charts],
   );
 
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [isTableVisible, setIsTableVisible] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(prefersTablePreview);
+  const [isTableVisible, setIsTableVisible] = useState(prefersTablePreview);
   const [charts, setCharts] = useState<ChartSpec[]>(initialCharts);
   const [chartHistory, setChartHistory] = useState<ChartHistoryState>(
     () => buildInitialChartHistory(initialCharts, workspace.workspaceId),

--- a/agent_app/tests/unit/test_agent_checkpointer_retry.py
+++ b/agent_app/tests/unit/test_agent_checkpointer_retry.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 import sys
 import types
+from collections import defaultdict
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
@@ -24,6 +25,11 @@ def _noop_context_manager(*_args, **_kwargs):
 mlflow_stub = types.ModuleType("mlflow")
 mlflow_stub.update_current_trace = lambda *args, **kwargs: None
 mlflow_stub.start_span = lambda *args, **kwargs: _noop_context_manager()
+mlflow_stub.start_span_no_context = lambda *args, **kwargs: SimpleNamespace(
+    set_inputs=lambda *_a, **_k: None,
+    set_outputs=lambda *_a, **_k: None,
+    end=lambda: None,
+)
 mlflow_stub.langchain = SimpleNamespace(autolog=lambda **_kwargs: None)
 sys.modules.setdefault("mlflow", mlflow_stub)
 
@@ -34,6 +40,10 @@ mlflow_entities_stub.SpanType = SimpleNamespace(
     RETRIEVER="retriever",
 )
 sys.modules.setdefault("mlflow.entities", mlflow_entities_stub)
+
+mlflow_tracing_provider_stub = types.ModuleType("mlflow.tracing.provider")
+mlflow_tracing_provider_stub.with_active_span = _noop_context_manager
+sys.modules.setdefault("mlflow.tracing.provider", mlflow_tracing_provider_stub)
 
 agent_server_decorators_stub = types.ModuleType("mlflow.genai.agent_server")
 agent_server_decorators_stub.get_request_headers = lambda: {}
@@ -220,3 +230,72 @@ def test_stream_handler_retries_once_on_recoverable_checkpointer_error(monkeypat
         and event.item["content"][0]["text"].strip() == "Recovered after retry"
         for event in events
     )
+
+
+def test_stream_handler_persists_summary_metadata_to_trace_outputs(monkeypatch):
+    captured_outputs = defaultdict(list)
+
+    class RecordingSpan:
+        def __init__(self, name):
+            self.name = name
+
+        def set_inputs(self, *_args, **_kwargs):
+            return None
+
+        def set_outputs(self, payload):
+            captured_outputs[self.name].append(payload)
+
+        def end(self):
+            return None
+
+    @contextmanager
+    def active_span(span):
+        yield span
+
+    class SuccessfulCompiledAppWithSummary:
+        def get_state(self, _run_config):
+            return SimpleNamespace(
+                tasks=[],
+                values={
+                    "final_summary": "Summary with ```viz-workspace\\n{\"workspaceId\":\"query-1\"}\\n```",
+                    "execution_result": {"status": "success", "row_count": 2},
+                },
+            )
+
+        def stream(self, *_args, **_kwargs):
+            yield ((), "custom", {"type": "summary_start", "content": "Generating summary..."})
+            yield ((), "custom", {"type": "text_delta", "content": "Summary with chart"})
+            yield ((), "custom", {"type": "summary_complete", "content": "Summary complete"})
+            yield (
+                (),
+                "updates",
+                {
+                    "summarize": {
+                        "messages": [_AIMessage(content="Summary with chart", id="ai-final")],
+                        "final_summary": "Summary with chart",
+                    }
+                },
+            )
+
+    app = SuccessfulCompiledAppWithSummary()
+
+    monkeypatch.setattr(agent_module, "_get_compiled_workflow_app", lambda: app)
+    monkeypatch.setattr(
+        agent_module.mlflow,
+        "start_span_no_context",
+        lambda name, **_kwargs: RecordingSpan(name),
+        raising=False,
+    )
+    monkeypatch.setattr(agent_module, "with_active_span", active_span)
+
+    events = asyncio.run(_collect_events())
+
+    assert any(getattr(event, "type", "") == "response.output_text.delta" for event in events)
+    assert captured_outputs["langgraph_workflow"][-1]["final_summary_length"] > 0
+    assert captured_outputs["langgraph_workflow"][-1]["has_viz_workspace"] is True
+    assert captured_outputs["langgraph_workflow"][-1]["viz_workspace_count"] == 1
+    assert "final_summary" not in captured_outputs["langgraph_workflow"][-1]
+    assert captured_outputs["chat_request"][-1]["final_summary_length"] > 0
+    assert captured_outputs["chat_request"][-1]["has_viz_workspace"] is True
+    assert captured_outputs["chat_request"][-1]["viz_workspace_count"] == 1
+    assert "final_summary" not in captured_outputs["chat_request"][-1]

--- a/agent_app/tests/unit/test_sequential_output_fixes.py
+++ b/agent_app/tests/unit/test_sequential_output_fixes.py
@@ -59,6 +59,7 @@ from agent_server.multi_agent.agents.chart_generator import (
     SUPPORTED_TRANSFORMS,
     _load_sqlglot,
 )
+from agent_server.multi_agent.agents import summarize as summarize_module
 from agent_server.multi_agent.agents.sql_execution import _append_remaining_skipped_artifacts
 from agent_server.multi_agent.agents.summarize import (
     _build_artifact_entries,
@@ -666,6 +667,65 @@ def test_build_visualization_workspace_payload_groups_table_and_chart():
     assert workspace["description"] == "Aggregated paid amount by month."
     assert workspace["sourceMeta"]["sqlExplanation"] is None
 
+
+def test_summarize_node_emits_workspace_fallback_when_chart_generation_returns_none(monkeypatch):
+    emitted = []
+
+    class StubSummarizeAgent:
+        def generate_summary(self, _context, writer=None):
+            if writer:
+                writer({"type": "text_delta", "content": "Summary body"})
+            return "Summary body"
+
+    class NullChartGenerator:
+        def generate_chart(self, *_args, **_kwargs):
+            return None
+
+    monkeypatch.setattr(summarize_module, "get_stream_writer", lambda: emitted.append)
+    monkeypatch.setattr(summarize_module, "get_cached_summarize_agent", lambda: StubSummarizeAgent())
+    monkeypatch.setattr(summarize_module, "_get_cached_chart_generator", lambda: NullChartGenerator())
+    monkeypatch.setattr(
+        summarize_module,
+        "get_config",
+        lambda: SimpleNamespace(
+            llm=SimpleNamespace(
+                summarize_endpoint="summary-endpoint",
+                chart_endpoint="chart-endpoint",
+                detect_code_lookup_endpoint="lookup-endpoint",
+            )
+        ),
+    )
+
+    result = summarize_module.summarize_node(
+        {
+            "original_query": "Show claims by month",
+            "messages": [],
+            "execution_results": [
+                {
+                    "success": True,
+                    "status": "success",
+                    "query_label": "Claims by month",
+                    "columns": ["service_month", "claim_count"],
+                    "result": [
+                        {"service_month": "2024-01", "claim_count": 10},
+                        {"service_month": "2024-02", "claim_count": 12},
+                    ],
+                    "row_count": 2,
+                    "sql": "SELECT service_month, claim_count FROM claims",
+                }
+            ],
+        }
+    )
+
+    assert "```viz-workspace" in result["final_summary"]
+    assert '"workspaceId": "query-1"' in result["final_summary"]
+    assert '"source": "fallback"' in result["final_summary"]
+    assert any(
+        event.get("type") == "text_delta" and "```viz-workspace" in event.get("content", "")
+        for event in emitted
+    )
+
+
 def test_chart_generator_frequency_rewrites_to_count_series():
     llm = StubLlm(
         """
@@ -885,6 +945,41 @@ def test_chart_generator_histogram_supports_count_distinct_metric():
     assert payload["config"]["series"][0]["field"] == "patient_id"
     assert payload["config"]["transform"]["function"] == "count_distinct"
     assert sum(row["patient_id"] for row in payload["chartData"]) == 4
+
+
+def test_chart_generator_time_bucket_supports_count_distinct_id_metric():
+    llm = StubLlm(
+        """
+        {
+          "plottable": true,
+          "chartType": "stackedArea",
+          "title": "Distinct Claims by Month",
+          "xAxisField": "date_service",
+          "groupByField": "claim_type",
+          "series": [{"field": "claim_id", "name": "Claims", "format": "number", "chartType": "area"}],
+          "transform": {"type": "timeBucket", "field": "date_service", "bucket": "month", "metric": "claim_id", "function": "count_distinct"}
+        }
+        """
+    )
+    generator = ChartGenerator(llm=llm)  # type: ignore[arg-type]
+
+    payload = generator.generate_chart(
+        columns=["date_service", "claim_id", "claim_type"],
+        data=[
+            {"date_service": "2024-01-01", "claim_id": "A", "claim_type": "medical"},
+            {"date_service": "2024-01-15", "claim_id": "A", "claim_type": "medical"},
+            {"date_service": "2024-01-20", "claim_id": "B", "claim_type": "medical"},
+            {"date_service": "2024-02-01", "claim_id": "C", "claim_type": "pharmacy"},
+        ],
+        original_query="Show distinct claims by month",
+    )
+
+    assert payload is not None
+    assert payload["config"]["chartType"] == "stackedArea"
+    assert payload["config"]["transform"]["function"] == "count_distinct"
+    assert payload["config"]["series"][0]["field"] == "claim_id"
+    assert any(row["claim_type"] == "medical" and row["claim_id"] == 2.0 for row in payload["chartData"])
+    assert any(row["claim_type"] == "pharmacy" and row["claim_id"] == 1.0 for row in payload["chartData"])
 
 
 def test_chart_generator_llm_numeric_x_axis_is_bucketed_to_histogram():


### PR DESCRIPTION
## Summary
- harden agent state extraction and summary trace metadata for summarize-node execution
- generate a fallback chart payload so the visualization workspace still renders when chart generation fails
- add unit coverage for fallback handling and summary metadata emission

## Test plan
- Not run in this PR workflow