### PR TITLE
Preserve richer SQL synthesis explanations and sync existing VS indexes

### DIFF
--- a/agent_app/agent_server/multi_agent/agents/sql_synthesis.py
+++ b/agent_app/agent_server/multi_agent/agents/sql_synthesis.py
@@ -82,6 +82,8 @@ _agent_cache = {}
 # LLM connection pool (module-level)
 _llm_connection_pool = {}
 
+SQL_SYNTHESIS_MAX_TOKENS = 8192 * 2
+
 
 # ==============================================================================
 # Helper Functions
@@ -234,7 +236,7 @@ def get_cached_sql_table_agent(llm_endpoint=None, catalog=None, schema=None):
     if "sql_table" not in _agent_cache:
         record_cache_miss("agent_cache")
         print("⚡ Creating SQLSynthesisTableAgent (first use)...")
-        llm = get_pooled_llm(llm_endpoint)
+        llm = get_pooled_llm(llm_endpoint, max_tokens=SQL_SYNTHESIS_MAX_TOKENS)
         _agent_cache["sql_table"] = SQLSynthesisTableAgent(llm, catalog, schema)
         print("✓ SQLSynthesisTableAgent cached")
     else:
@@ -533,7 +535,11 @@ def sql_synthesis_genie_node(state: AgentState) -> dict:
     
     # Use dedicated SQL_SYNTHESIS_GENIE endpoint for orchestrating multiple Genie agents
     # This agent requires stronger reasoning for complex coordination
-    llm = get_pooled_llm(llm_endpoint, temperature=0.1)
+    llm = get_pooled_llm(
+        llm_endpoint,
+        temperature=0.1,
+        max_tokens=SQL_SYNTHESIS_MAX_TOKENS,
+    )
     
     if not relevant_spaces:
         print("❌ No relevant_spaces found in state")

--- a/agent_app/agent_server/multi_agent/agents/sql_synthesis_agents.py
+++ b/agent_app/agent_server/multi_agent/agents/sql_synthesis_agents.py
@@ -101,6 +101,55 @@ from databricks_langchain import (
 _genie_agent_pool: Dict[str, Any] = {}
 
 
+def _message_content_to_text(content: Any) -> str:
+    """Normalize LangChain message content into a plain text string."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: List[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(part for part in parts if part)
+    return str(content or "")
+
+
+def _get_recent_assistant_texts(messages: List[Any], limit: int = 2) -> List[str]:
+    """Collect the most recent assistant-authored text messages."""
+    assistant_texts: List[str] = []
+
+    for message in reversed(messages or []):
+        role = getattr(message, "type", None)
+        if role is None and isinstance(message, dict):
+            role = message.get("role")
+
+        if role not in {"ai", "assistant"}:
+            continue
+
+        if isinstance(message, dict):
+            content = message.get("content")
+            text = _message_content_to_text(content).strip()
+        else:
+            text_attr = getattr(message, "text", None)
+            if isinstance(text_attr, str):
+                text = text_attr.strip()
+            else:
+                content = getattr(message, "content", "")
+                text = _message_content_to_text(content).strip()
+        if not text:
+            continue
+
+        assistant_texts.append(text)
+        if len(assistant_texts) >= limit:
+            break
+
+    return list(reversed(assistant_texts))
+
+
 def get_or_create_genie_agent(space_id: str, space_title: str, description: str):
     """
     Get existing Genie agent from pool or create new one if not cached.
@@ -302,8 +351,10 @@ Use your available UC function tools to gather metadata intelligently.
         
         # Extract SQL and explanation from response
         if result and "messages" in result:
-            final_content = result["messages"][-1].content
-            original_content = final_content
+            assistant_texts = _get_recent_assistant_texts(result["messages"], limit=2)
+            final_content = assistant_texts[-1] if assistant_texts else _message_content_to_text(result["messages"][-1].content)
+            explanation_source = "\n\n".join(assistant_texts) if assistant_texts else final_content
+            original_content = explanation_source
             
             sql_query = None
             has_sql = False
@@ -316,8 +367,6 @@ Use your available UC function tools to gather metadata intelligently.
                     # Join all SQL blocks with newlines to preserve multi-query structure
                     sql_query = '\n\n'.join(block.strip() for block in sql_blocks if block.strip())
                     has_sql = True
-                    # Remove all SQL blocks from content to get explanation
-                    final_content = re.sub(r'```sql\s*.*?\s*```', '', final_content, flags=re.IGNORECASE | re.DOTALL)
             elif "```" in final_content:
                 # Find all generic code blocks
                 code_blocks = re.findall(r'```\s*(.*?)\s*```', final_content, re.DOTALL)
@@ -330,11 +379,14 @@ Use your available UC function tools to gather metadata intelligently.
                     # Join all SQL blocks
                     sql_query = '\n\n'.join(sql_blocks)
                     has_sql = True
-                    # Remove all code blocks from content to get explanation
-                    final_content = re.sub(r'```\s*.*?\s*```', '', final_content, flags=re.DOTALL)
             
             # Clean up explanation
-            explanation = final_content.strip()
+            explanation = explanation_source
+            if "```sql" in explanation.lower():
+                explanation = re.sub(r'```sql\s*.*?\s*```', '', explanation, flags=re.IGNORECASE | re.DOTALL)
+            elif "```" in explanation:
+                explanation = re.sub(r'```\s*.*?\s*```', '', explanation, flags=re.DOTALL)
+            explanation = explanation.strip()
             if not explanation:
                 explanation = original_content if not has_sql else "SQL query generated successfully."
             
@@ -915,8 +967,10 @@ Then combine them into a final SQL query.
             # Extract SQL from agent result
             # The agent returns {"messages": [...]}
             # Last message contains the final response
+            assistant_texts = _get_recent_assistant_texts(result["messages"], limit=2)
             final_message = result["messages"][-1]
-            final_content = final_message.content.strip()
+            final_content = assistant_texts[-1] if assistant_texts else _message_content_to_text(final_message.content).strip()
+            explanation_source = "\n\n".join(assistant_texts) if assistant_texts else final_content
             
             print(f"\n{'='*80}")
             print("✅ SQL Synthesis Agent completed")
@@ -927,7 +981,7 @@ Then combine them into a final SQL query.
             # Extract SQL and explanation from the result
             sql_query = None
             has_sql = False
-            explanation = final_content
+            explanation = explanation_source
             
             # Clean markdown if present and extract SQL - use findall to capture ALL code blocks
             if "```sql" in final_content.lower():
@@ -937,8 +991,6 @@ Then combine them into a final SQL query.
                     # Join all SQL blocks with newlines to preserve multi-query structure
                     sql_query = '\n\n'.join(block.strip() for block in sql_blocks if block.strip())
                     has_sql = True
-                    # Remove all SQL blocks to get explanation
-                    explanation = re.sub(r'```sql\s*.*?\s*```', '', final_content, flags=re.IGNORECASE | re.DOTALL)
             elif "```" in final_content:
                 # Find all generic code blocks
                 code_blocks = re.findall(r'```\s*(.*?)\s*```', final_content, re.DOTALL)
@@ -951,8 +1003,6 @@ Then combine them into a final SQL query.
                     # Join all SQL blocks
                     sql_query = '\n\n'.join(sql_blocks)
                     has_sql = True
-                    # Remove all code blocks to get explanation
-                    explanation = re.sub(r'```\s*.*?\s*```', '', final_content, flags=re.DOTALL)
             else:
                 # No markdown, check if the entire content is SQL
                 if any(keyword in final_content.upper() for keyword in ['SELECT', 'FROM', 'WHERE', 'JOIN']):
@@ -960,6 +1010,10 @@ Then combine them into a final SQL query.
                     has_sql = True
                     explanation = "SQL query generated successfully by Genie agent tools."
             
+            if "```sql" in explanation.lower():
+                explanation = re.sub(r'```sql\s*.*?\s*```', '', explanation, flags=re.IGNORECASE | re.DOTALL)
+            elif "```" in explanation:
+                explanation = re.sub(r'```\s*.*?\s*```', '', explanation, flags=re.DOTALL)
             explanation = explanation.strip()
             if not explanation:
                 explanation = final_content if not has_sql else "SQL query generated successfully by Genie agent tools."

--- a/etl/03_build_vector_search_index.py
+++ b/etl/03_build_vector_search_index.py
@@ -121,7 +121,7 @@ print(f"✓ Endpoint '{vs_endpoint_name}' is online and ready")
 
 # COMMAND ----------
 
-# DBTITLE 1,Create Delta Sync Vector Search Index
+# DBTITLE 1,Create or Sync Delta Sync Vector Search Index
 
 print(f"Creating vector search index: {index_name}")
 print(f"  Source: {source_table_name}")
@@ -132,25 +132,23 @@ print(f"  Embedding model: {embedding_model}")
 try:
     # Check if index already exists
     try:
-        existing_index = client.get_index(index_name=index_name)
-        print(f"Index '{index_name}' already exists. Deleting and recreating...")
-        client.delete_index(index_name=index_name)
-        time.sleep(5)  # Wait for deletion to complete
+        index = client.get_index(index_name=index_name)
+        print(f"Index '{index_name}' already exists. Triggering sync...")
+        index.sync()
     except Exception:
         print(f"Index does not exist, creating new...")
+        # Create new index with metadata filters
+        index = client.create_delta_sync_index(
+            endpoint_name=vs_endpoint_name,
+            source_table_name=source_table_name,
+            index_name=index_name,
+            pipeline_type=pipeline_type,
+            primary_key="chunk_id",
+            embedding_source_column="searchable_content",
+            embedding_model_endpoint_name=embedding_model
+        )
     
-    # Create new index with metadata filters
-    index = client.create_delta_sync_index(
-        endpoint_name=vs_endpoint_name,
-        source_table_name=source_table_name,
-        index_name=index_name,
-        pipeline_type=pipeline_type,
-        primary_key="chunk_id",
-        embedding_source_column="searchable_content",
-        embedding_model_endpoint_name=embedding_model
-    )
-    
-    print(f"✓ Vector search index creation initiated: {index_name}")
+    print(f"✓ Vector search index creation/sync initiated: {index_name}: {index}")
     print(f"  Metadata fields available for filtering:")
     print(f"    - chunk_type (space_summary, table_overview, column_detail)")
     print(f"    - table_name, column_name")


### PR DESCRIPTION
## Summary
- preserve richer SQL synthesis explanations by keeping the two most recent assistant-authored synthesis messages, while still extracting executable SQL from the final assistant message only
- improve SQL synthesis robustness by preferring `message.text` when available and increasing the pooled LLM token ceiling for larger query generation flows
- update vector search index maintenance to sync existing indices instead of deleting and recreating them, reducing churn during ETL runs

## Test plan
- [x] Verified the extraction logic with a focused Python check that simulated assistant and tool messages
- [x] Confirmed the updated files have no linter errors via `ReadLints`
- [x] Run an end-to-end table-route request in the local app and confirm the SQL Explanation accordion shows both synthesis and polish context
- [x] Run the vector search index create-or-sync flow against a workspace with an existing index